### PR TITLE
Update ck-system-stop with "shutdown -p"

### DIFF
--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-shutdown -h now
+shutdown -p now


### PR DESCRIPTION
Replace -h with -p in shutdown command. On some systems it might just halt and leave the power on.