### PR TITLE
Use poweroff instead shutdown command in ck-system-stop

### DIFF
--- a/tools/linux/ck-system-stop
+++ b/tools/linux/ck-system-stop
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-shutdown -h now
+poweroff


### PR DESCRIPTION
I've tested it and it works in Runit, SysV, and S6.