### PR TITLE
include <stdint.h> in sd-login.h

### DIFF
--- a/libconsolekit/sd-login.h
+++ b/libconsolekit/sd-login.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sys/types.h>
+#include <stdint.h>
 
 typedef struct
 {


### PR DESCRIPTION
FTBFS with a source updated with the latest commit. ---
In file included from sd-compat.c:50:
sd-login.h:18:61: error: unknown type name 'uint64_t'
   18 | int sd_login_monitor_get_timeout(sd_login_monitor *monitor, uint64_t *timeout_usec);
      |                                                             ^~~~~~~~
sd-login.h:1:1: note: 'uint64_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
  +++ |+#include <stdint.h>
    1 | #pragma once
sd-compat.c:482:61: error: unknown type name 'uint64_t'
  482 | int sd_login_monitor_get_timeout(sd_login_monitor *monitor, uint64_t *timeout_usec)
      |                                                             ^~~~~~~~
sd-compat.c:51:1: note: 'uint64_t' is defined in header '<stdint.h>'; this is probably fixable by adding '#include <stdint.h>'
   50 | #include "sd-login.h"
  +++ |+#include <stdint.h>
   51 | 
---